### PR TITLE
feat: Add plain text responses

### DIFF
--- a/lib/apia/rack.rb
+++ b/lib/apia/rack.rb
@@ -152,6 +152,20 @@ module Apia
 
     class << self
 
+      # Return a triplet for the given body.
+      #
+      # @param body [Hash, Array]
+      # @param status [Integer]
+      # @param headers [Hash]
+      # @return [Array]
+      def plain_triplet(body, status: 200, headers: {})
+        [
+          status,
+          headers.merge('content-type' => 'text/plain', 'content-length' => body.bytesize.to_s),
+          [body]
+        ]
+      end
+
       # Return a JSON-ready triplet for the given body.
       #
       # @param body [Hash, Array]

--- a/lib/apia/rack.rb
+++ b/lib/apia/rack.rb
@@ -152,18 +152,14 @@ module Apia
 
     class << self
 
-      # Return a triplet for the given body.
+      # Return a plain text triplet for the given body.
       #
-      # @param body [Hash, Array]
+      # @param body [String]
       # @param status [Integer]
       # @param headers [Hash]
       # @return [Array]
       def plain_triplet(body, status: 200, headers: {})
-        [
-          status,
-          headers.merge('content-type' => 'text/plain', 'content-length' => body.bytesize.to_s),
-          [body]
-        ]
+        response_triplet(body, content_type: 'text/plain', status: status, headers: headers)
       end
 
       # Return a JSON-ready triplet for the given body.
@@ -173,11 +169,21 @@ module Apia
       # @param headers [Hash]
       # @return [Array]
       def json_triplet(body, status: 200, headers: {})
-        body_as_json = body.to_json
+        response_triplet(body.to_json, content_type: 'application/json', status: status, headers: headers)
+      end
+
+      # Return a triplet for the given body.
+      #
+      # @param body [Hash, Array]
+      # @param content_type [String]
+      # @param status [Integer]
+      # @param headers [Hash]
+      # @return [Array]
+      def response_triplet(body, content_type:, status: 200, headers: {})
         [
           status,
-          headers.merge('content-type' => 'application/json', 'content-length' => body_as_json.bytesize.to_s),
-          [body_as_json]
+          headers.merge('content-type' => content_type, 'content-length' => body.bytesize.to_s),
+          [body]
         ]
       end
 

--- a/lib/apia/rack.rb
+++ b/lib/apia/rack.rb
@@ -180,10 +180,13 @@ module Apia
       # @param headers [Hash]
       # @return [Array]
       def response_triplet(body, content_type:, status: 200, headers: {})
+        content_length = body.bytesize.to_s
+        body = [body] unless body.respond_to?(:each)
+
         [
           status,
-          headers.merge('content-type' => content_type, 'content-length' => body.bytesize.to_s),
-          [body]
+          headers.merge('content-type' => content_type, 'content-length' => content_length),
+          body
         ]
       end
 

--- a/lib/apia/response.rb
+++ b/lib/apia/response.rb
@@ -25,9 +25,9 @@ module Apia
       @headers = {}
     end
 
-    def plain!
+    def plain_text_body(body)
       @type = PLAIN
-      @body = ''
+      @body = body
     end
 
     # Add a field value for this endpoint

--- a/lib/apia/response.rb
+++ b/lib/apia/response.rb
@@ -10,6 +10,7 @@ module Apia
     attr_reader :fields
     attr_reader :headers
     attr_writer :body
+    attr_writer :type
 
     def initialize(request, endpoint)
       @request = request
@@ -53,11 +54,18 @@ module Apia
       @body || hash
     end
 
+    def type
+      @type || :json
+    end
+
     # Return the rack triplet for this response
     #
     # @return [Array]
     def rack_triplet
-      Rack.json_triplet(body, headers: @headers, status: @status)
+      return Rack.json_triplet(body, headers: @headers, status: @status) if type == :json
+      return Rack.plain_triplet(body, headers: @headers, status: @status) if type == :plain
+
+      raise "Unknown response type '#{type}'"
     end
 
   end

--- a/spec/specs/apia/rack_spec.rb
+++ b/spec/specs/apia/rack_spec.rb
@@ -351,6 +351,49 @@ describe Apia::Rack do
     end
   end
 
+  context '.plain_triplet' do
+    it 'should return json encoded data' do
+      data = 'hello world'
+      triplet = Apia::Rack.plain_triplet(data)
+      expect(triplet).to be_a Array
+      expect(triplet[0]).to eq 200
+      expect(triplet[1]).to be_a Hash
+      expect(triplet[2]).to be_a Array
+      expect(triplet[2][0]).to eq 'hello world'
+    end
+
+    it 'should set the content type' do
+      data = 'hello world'
+      triplet = Apia::Rack.plain_triplet(data)
+      expect(triplet).to be_a Array
+      expect(triplet[1]['content-type']).to eq 'text/plain'
+    end
+
+    it 'should set the content length' do
+      data = 'hello world'
+      triplet = Apia::Rack.plain_triplet(data)
+      expect(triplet).to be_a Array
+      expect(triplet[1]['content-length']).to eq '11'
+    end
+
+    it 'should set the status' do
+      data = 'hello world'
+      triplet = Apia::Rack.plain_triplet(data, status: 400)
+      expect(triplet).to be_a Array
+      expect(triplet[0]).to eq 400
+    end
+
+    it 'should merge additional headers' do
+      data = 'hello world'
+      triplet = Apia::Rack.plain_triplet(data, headers: { 'x-something' => 'hello' })
+      expect(triplet).to be_a Array
+      expect(triplet[1]).to be_a Hash
+      expect(triplet[1]['x-something']).to eq 'hello'
+      expect(triplet[1]['content-length']).to eq '11'
+      expect(triplet[1]['content-type']).to eq 'text/plain'
+    end
+  end
+
   context '.error_triplet' do
     it 'should format the JSON appropriately' do
       triplet = Apia::Rack.error_triplet('example_error', description: 'Some example', detail: { hello: 'world' })

--- a/spec/specs/apia/response_spec.rb
+++ b/spec/specs/apia/response_spec.rb
@@ -34,52 +34,111 @@ describe Apia::Response do
   end
 
   context '#rack_triplet' do
-    it 'should return 200 by default' do
-      endpoint = Apia::Endpoint.create('ExampleEndpoint')
-      response = Apia::Response.new(request, endpoint)
-      expect(response.rack_triplet[0]).to eq 200
+    context 'with a JSON response' do
+      it 'should return 200 by default' do
+        endpoint = Apia::Endpoint.create('ExampleEndpoint')
+        response = Apia::Response.new(request, endpoint)
+        expect(response.rack_triplet[0]).to eq 200
+      end
+
+      it 'should return whatever the status is set to' do
+        endpoint = Apia::Endpoint.create('ExampleEndpoint')
+        response = Apia::Response.new(request, endpoint)
+        response.status = 403
+        expect(response.rack_triplet[0]).to eq 403
+      end
+
+      it 'should return the status from the endpoint' do
+        endpoint = Apia::Endpoint.create('ExampleEndpoint')
+        endpoint.http_status :created
+        response = Apia::Response.new(request, endpoint)
+        expect(response.rack_triplet[0]).to eq 201
+      end
+
+      it 'should return the headers' do
+        endpoint = Apia::Endpoint.create('ExampleEndpoint')
+        response = Apia::Response.new(request, endpoint)
+        response.add_header 'x-example', 'hello world'
+        expect(response.rack_triplet[1]['x-example']).to eq 'hello world'
+      end
+
+      it 'should always provide the content-type as json' do
+        endpoint = Apia::Endpoint.create('ExampleEndpoint')
+        response = Apia::Response.new(request, endpoint)
+        expect(response.rack_triplet[1]['content-type']).to eq 'application/json'
+      end
+
+      it 'should always set a content-length' do
+        endpoint = Apia::Endpoint.create('ExampleEndpoint')
+        response = Apia::Response.new(request, endpoint)
+        expect(response.rack_triplet[2][0]).to eq '{}'
+        expect(response.rack_triplet[1]['content-length']).to eq '2'
+      end
+
+      it 'should return the body if one has been set' do
+        endpoint = Apia::Endpoint.create('ExampleEndpoint')
+        response = Apia::Response.new(request, endpoint)
+        response.body = { hello: 'world' }
+        expect(response.rack_triplet[2][0]).to eq '{"hello":"world"}'
+        expect(response.rack_triplet[1]['content-length']).to eq '17'
+      end
     end
 
-    it 'should return whatever the status is set to' do
-      endpoint = Apia::Endpoint.create('ExampleEndpoint')
-      response = Apia::Response.new(request, endpoint)
-      response.status = 403
-      expect(response.rack_triplet[0]).to eq 403
-    end
+    context 'with a plain text response' do
+      it 'should return 200 by default' do
+        endpoint = Apia::Endpoint.create('ExampleEndpoint')
+        response = Apia::Response.new(request, endpoint)
+        response.plain!
+        expect(response.rack_triplet[0]).to eq 200
+      end
 
-    it 'should return the status from the endpoint' do
-      endpoint = Apia::Endpoint.create('ExampleEndpoint')
-      endpoint.http_status :created
-      response = Apia::Response.new(request, endpoint)
-      expect(response.rack_triplet[0]).to eq 201
-    end
+      it 'should return whatever the status is set to' do
+        endpoint = Apia::Endpoint.create('ExampleEndpoint')
+        response = Apia::Response.new(request, endpoint)
+        response.plain!
+        response.status = 403
+        expect(response.rack_triplet[0]).to eq 403
+      end
 
-    it 'should return the headers' do
-      endpoint = Apia::Endpoint.create('ExampleEndpoint')
-      response = Apia::Response.new(request, endpoint)
-      response.add_header 'x-example', 'hello world'
-      expect(response.rack_triplet[1]['x-example']).to eq 'hello world'
-    end
+      it 'should return the status from the endpoint' do
+        endpoint = Apia::Endpoint.create('ExampleEndpoint')
+        endpoint.http_status :created
+        response = Apia::Response.new(request, endpoint)
+        response.plain!
+        expect(response.rack_triplet[0]).to eq 201
+      end
 
-    it 'should always provide the content-type as json' do
-      endpoint = Apia::Endpoint.create('ExampleEndpoint')
-      response = Apia::Response.new(request, endpoint)
-      expect(response.rack_triplet[1]['content-type']).to eq 'application/json'
-    end
+      it 'should return the headers' do
+        endpoint = Apia::Endpoint.create('ExampleEndpoint')
+        response = Apia::Response.new(request, endpoint)
+        response.plain!
+        response.add_header 'x-example', 'hello world'
+        expect(response.rack_triplet[1]['x-example']).to eq 'hello world'
+      end
 
-    it 'should always set a content-length' do
-      endpoint = Apia::Endpoint.create('ExampleEndpoint')
-      response = Apia::Response.new(request, endpoint)
-      expect(response.rack_triplet[2][0]).to eq '{}'
-      expect(response.rack_triplet[1]['content-length']).to eq '2'
-    end
+      it 'should always provide the content-type as plain' do
+        endpoint = Apia::Endpoint.create('ExampleEndpoint')
+        response = Apia::Response.new(request, endpoint)
+        response.plain!
+        expect(response.rack_triplet[1]['content-type']).to eq 'text/plain'
+      end
 
-    it 'should return the body if one has been set' do
-      endpoint = Apia::Endpoint.create('ExampleEndpoint')
-      response = Apia::Response.new(request, endpoint)
-      response.body = { hello: 'world' }
-      expect(response.rack_triplet[2][0]).to eq '{"hello":"world"}'
-      expect(response.rack_triplet[1]['content-length']).to eq '17'
+      it 'should always set a content-length' do
+        endpoint = Apia::Endpoint.create('ExampleEndpoint')
+        response = Apia::Response.new(request, endpoint)
+        response.plain!
+        expect(response.rack_triplet[2][0]).to eq ''
+        expect(response.rack_triplet[1]['content-length']).to eq '0'
+      end
+
+      it 'should return the body if one has been set' do
+        endpoint = Apia::Endpoint.create('ExampleEndpoint')
+        response = Apia::Response.new(request, endpoint)
+        response.plain!
+        response.body = 'hello world'
+        expect(response.rack_triplet[2][0]).to eq 'hello world'
+        expect(response.rack_triplet[1]['content-length']).to eq '11'
+      end
     end
   end
 end

--- a/spec/specs/apia/response_spec.rb
+++ b/spec/specs/apia/response_spec.rb
@@ -88,14 +88,14 @@ describe Apia::Response do
       it 'should return 200 by default' do
         endpoint = Apia::Endpoint.create('ExampleEndpoint')
         response = Apia::Response.new(request, endpoint)
-        response.plain!
+        response.plain_text_body('hello world')
         expect(response.rack_triplet[0]).to eq 200
       end
 
       it 'should return whatever the status is set to' do
         endpoint = Apia::Endpoint.create('ExampleEndpoint')
         response = Apia::Response.new(request, endpoint)
-        response.plain!
+        response.plain_text_body('hello world')
         response.status = 403
         expect(response.rack_triplet[0]).to eq 403
       end
@@ -104,29 +104,29 @@ describe Apia::Response do
         endpoint = Apia::Endpoint.create('ExampleEndpoint')
         endpoint.http_status :created
         response = Apia::Response.new(request, endpoint)
-        response.plain!
+        response.plain_text_body('hello world')
         expect(response.rack_triplet[0]).to eq 201
       end
 
       it 'should return the headers' do
         endpoint = Apia::Endpoint.create('ExampleEndpoint')
         response = Apia::Response.new(request, endpoint)
-        response.plain!
-        response.add_header 'x-example', 'hello world'
-        expect(response.rack_triplet[1]['x-example']).to eq 'hello world'
+        response.plain_text_body('hello world')
+        response.add_header 'x-example', 'hi!'
+        expect(response.rack_triplet[1]['x-example']).to eq 'hi!'
       end
 
       it 'should always provide the content-type as plain' do
         endpoint = Apia::Endpoint.create('ExampleEndpoint')
         response = Apia::Response.new(request, endpoint)
-        response.plain!
+        response.plain_text_body('hello world')
         expect(response.rack_triplet[1]['content-type']).to eq 'text/plain'
       end
 
       it 'should always set a content-length' do
         endpoint = Apia::Endpoint.create('ExampleEndpoint')
         response = Apia::Response.new(request, endpoint)
-        response.plain!
+        response.plain_text_body('')
         expect(response.rack_triplet[2][0]).to eq ''
         expect(response.rack_triplet[1]['content-length']).to eq '0'
       end
@@ -134,8 +134,7 @@ describe Apia::Response do
       it 'should return the body if one has been set' do
         endpoint = Apia::Endpoint.create('ExampleEndpoint')
         response = Apia::Response.new(request, endpoint)
-        response.plain!
-        response.body = 'hello world'
+        response.plain_text_body('hello world')
         expect(response.rack_triplet[2][0]).to eq 'hello world'
         expect(response.rack_triplet[1]['content-length']).to eq '11'
       end


### PR DESCRIPTION
Adds the option to return plain text from an Apia API, by calling `response.plain_text_body`, and passing in the body content