### PR TITLE
feat: Add response type option to endpoints

### DIFF
--- a/lib/apia/definitions/endpoint.rb
+++ b/lib/apia/definitions/endpoint.rb
@@ -14,6 +14,7 @@ module Apia
       attr_accessor :authenticator
       attr_accessor :action
       attr_accessor :http_status
+      attr_accessor :response_type
       attr_accessor :paginated_field
       attr_reader :fields
       attr_reader :scopes
@@ -21,6 +22,7 @@ module Apia
       def setup
         @fields = FieldSet.new
         @http_status = 200
+        @response_type = Apia::Response::JSON
         @scopes = []
       end
 

--- a/lib/apia/dsls/endpoint.rb
+++ b/lib/apia/dsls/endpoint.rb
@@ -40,6 +40,10 @@ module Apia
         @definition.http_status = status
       end
 
+      def response_type(type)
+        @definition.response_type = type
+      end
+
       def field(name, *args, type: nil, **options, &block)
         if @definition.fields_overriden?
           raise Apia::StandardError, 'Cannot add fields to an endpoint that has a separate fieldset'

--- a/lib/apia/rack.rb
+++ b/lib/apia/rack.rb
@@ -159,7 +159,7 @@ module Apia
       # @param headers [Hash]
       # @return [Array]
       def plain_triplet(body, status: 200, headers: {})
-        response_triplet(body, content_type: 'text/plain', status: status, headers: headers)
+        response_triplet(body, content_type: Apia::Response::PLAIN, status: status, headers: headers)
       end
 
       # Return a JSON-ready triplet for the given body.
@@ -169,7 +169,7 @@ module Apia
       # @param headers [Hash]
       # @return [Array]
       def json_triplet(body, status: 200, headers: {})
-        response_triplet(body.to_json, content_type: 'application/json', status: status, headers: headers)
+        response_triplet(body.to_json, content_type: Apia::Response::JSON, status: status, headers: headers)
       end
 
       # Return a triplet for the given body.

--- a/lib/apia/response.rb
+++ b/lib/apia/response.rb
@@ -7,8 +7,8 @@ module Apia
   class Response
 
     TYPES = [
-      JSON = :json,
-      PLAIN = :plain
+      JSON = 'application/json',
+      PLAIN = 'text/plain'
     ].freeze
 
     attr_accessor :status
@@ -21,11 +21,14 @@ module Apia
       @endpoint = endpoint
 
       @status = @endpoint.definition.http_status_code
+      @type = @endpoint.definition.response_type
       @fields = {}
       @headers = {}
     end
 
     def plain_text_body(body)
+      warn '[DEPRECATION] `plain_text_body` is deprecated. Please set use `response_type` in the endpoint definition, and set the response `body` directly instead.'
+
       @type = PLAIN
       @body = body
     end
@@ -63,15 +66,11 @@ module Apia
       @body || hash
     end
 
-    def type
-      @type || JSON
-    end
-
     # Return the rack triplet for this response
     #
     # @return [Array]
     def rack_triplet
-      case type
+      case @type
       when JSON
         Rack.json_triplet(body, headers: headers, status: status)
       when PLAIN


### PR DESCRIPTION
Refactors the way in which the response type is set to be part of the endpoint definition DSL, rather than at runtime via the `plain_text_body` method, as this allows Open API to infer the response type from the endpoint definition

The `plain_text_body` method has been left in for backwards compatibility, but marked as depreciated, as it doesn't play nice with our Open API library

Once this is released we can update the Open API lib to support plain text responses - https://github.com/apiaframework/apia-openapi/pull/62