### PR TITLE
fix: Ensure plain text response is only used for strings

### DIFF
--- a/lib/apia/definitions/error.rb
+++ b/lib/apia/definitions/error.rb
@@ -37,7 +37,7 @@ module Apia
       # API.
       #
       # @param errors [Apia::ManifestErrors]
-      # @reeturn [void]
+      # @return [void]
       def validate(errors)
         unless code.is_a?(Symbol)
           errors.add self, 'InvalidCode', 'Code must be a symbol'

--- a/lib/apia/response.rb
+++ b/lib/apia/response.rb
@@ -70,11 +70,14 @@ module Apia
     #
     # @return [Array]
     def rack_triplet
-      case @type
-      when JSON
-        Rack.json_triplet(body, headers: headers, status: status)
-      when PLAIN
+      # Errors will always be sent as a hash intended for JSON encoding,
+      # even if the endpoint specifies a plain text response, so only
+      # send a pain response if the type is plaintext _and_ the body is
+      # a string
+      if @type == PLAIN && body.is_a?(String)
         Rack.plain_triplet(body, headers: headers, status: status)
+      else
+        Rack.json_triplet(body, headers: headers, status: status)
       end
     end
 

--- a/spec/specs/apia/response_spec.rb
+++ b/spec/specs/apia/response_spec.rb
@@ -135,6 +135,14 @@ describe Apia::Response do
         expect(response.rack_triplet[2][0]).to eq 'hello world'
         expect(response.rack_triplet[1]['content-length']).to eq '11'
       end
+
+      it 'should return JSON if the body is not a string' do
+        response = Apia::Response.new(request, endpoint)
+        response.body = { hello: 'world' }
+        expect(response.rack_triplet[1]['content-type']).to eq 'application/json'
+        expect(response.rack_triplet[1]['content-length']).to eq '17'
+        expect(response.rack_triplet[2][0]).to eq '{"hello":"world"}'
+      end
     end
 
     context 'with a legacy plain text response' do


### PR DESCRIPTION
It turns out when expected errors occur (eg: those defined via `potential_error` in an endpoint) they are still handled via the response `rack_triplet` method. This means the error hash was being treated as plain text instead of JSON if the endpoint specified a plain text response

This PR fixes that by only rendering a plain text response if the type is plain text _and_ the response body is a string