### PR TITLE
fix: Ensure CORS headers are still added when an error occurs in the authenticator

### DIFF
--- a/apia.gemspec
+++ b/apia.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |s|
   s.authors       = ['Adam Cooke']
   s.email         = ['adam@k.io']
   s.licenses      = ['MIT']
-  s.add_runtime_dependency 'json'
-  s.add_runtime_dependency 'rack'
+  s.add_dependency 'json'
+  s.add_dependency 'rack'
 end

--- a/lib/apia/dsls/endpoint.rb
+++ b/lib/apia/dsls/endpoint.rb
@@ -69,7 +69,7 @@ module Apia
 
           field :pagination, type: PaginationObject
         end
-        super(name, *args, type: type, **options, &block)
+        super
       end
 
       def fields(fieldset)

--- a/lib/apia/request.rb
+++ b/lib/apia/request.rb
@@ -36,7 +36,7 @@ module Apia
     end
 
     def body?
-      has_header?('rack.input')
+      has_header?(::Rack::RACK_INPUT)
     end
 
     def params

--- a/spec/specs/apia/argument_set_spec.rb
+++ b/spec/specs/apia/argument_set_spec.rb
@@ -40,7 +40,7 @@ describe Apia::ArgumentSet do
     end
 
     it 'should create a new set using HTTP params if provided' do
-      env = Rack::MockRequest.env_for('/?name=michael')
+      env = Rack::MockRequest.env_for('/?name=michael', :input => '')
       request = Apia::Request.new(env)
       as = Apia::ArgumentSet.create('ExampleSet') do
         argument :name, type: :string

--- a/spec/specs/apia/argument_set_spec.rb
+++ b/spec/specs/apia/argument_set_spec.rb
@@ -40,7 +40,7 @@ describe Apia::ArgumentSet do
     end
 
     it 'should create a new set using HTTP params if provided' do
-      env = Rack::MockRequest.env_for('/?name=michael', :input => '')
+      env = Rack::MockRequest.env_for('/?name=michael', input: '')
       request = Apia::Request.new(env)
       as = Apia::ArgumentSet.create('ExampleSet') do
         argument :name, type: :string

--- a/spec/specs/apia/endpoint_spec.rb
+++ b/spec/specs/apia/endpoint_spec.rb
@@ -12,7 +12,7 @@ describe Apia::Endpoint do
   context '.execute' do
     context 'authenticators' do
       it 'should call the endpoint authenticator if one has been set' do
-        request = Apia::Request.new(Rack::MockRequest.env_for('/', input: ''))
+        request = Apia::Request.new(Rack::MockRequest.env_for('/', :input => ''))
 
         api_auth = Apia::Authenticator.create('ExampleAPIAuthenticator')
         api_auth.action { response.add_header 'x-auth', 'api' }
@@ -45,7 +45,7 @@ describe Apia::Endpoint do
       end
 
       it 'should call the controller authenticator if one has been set' do
-        request = Apia::Request.new(Rack::MockRequest.env_for('/', input: ''))
+        request = Apia::Request.new(Rack::MockRequest.env_for('/', :input => ''))
 
         api_auth = Apia::Authenticator.create('ExampleAPIAuthenticator')
         api_auth.action { response.add_header 'x-auth', 'api' }
@@ -75,7 +75,7 @@ describe Apia::Endpoint do
       end
 
       it 'should call the API authenticator' do
-        request = Apia::Request.new(Rack::MockRequest.env_for('/', input: ''))
+        request = Apia::Request.new(Rack::MockRequest.env_for('/', :input => ''))
 
         api_auth = Apia::Authenticator.create('ExampleAPIAuthenticator')
         api_auth.action { response.add_header 'x-auth', 'api' }
@@ -92,7 +92,7 @@ describe Apia::Endpoint do
       end
 
       it 'checks the scopes are valid' do
-        request = Apia::Request.new(Rack::MockRequest.env_for('/', input: ''))
+        request = Apia::Request.new(Rack::MockRequest.env_for('/', :input => ''))
 
         api_auth = Apia::Authenticator.create('ExampleAPIAuthenticator') do
           scope_validator { |e| e == 'not-example' }
@@ -130,7 +130,7 @@ describe Apia::Endpoint do
       end
 
       it 'should create an argument set from standard HTTP query string parameters' do
-        request = Apia::Request.new(Rack::MockRequest.env_for('/?name=Adam'))
+        request = Apia::Request.new(Rack::MockRequest.env_for('/?name=Adam', :input => ''))
         request.endpoint = Apia::Endpoint.create('Endpoint') do
           argument :name, type: :string
         end
@@ -144,7 +144,7 @@ describe Apia::Endpoint do
       context 'it includes CORS headers in the response' do
         context 'when nothing is specified' do
           it 'includes wildcard CORS headers' do
-            request = Apia::Request.new(Rack::MockRequest.env_for('/', input: ''))
+            request = Apia::Request.new(Rack::MockRequest.env_for('/', :input => ''))
             endpoint = Apia::Endpoint.create('Endpoint')
             response = endpoint.execute(request)
             expect(response.headers['Access-Control-Allow-Origin']).to eq '*'
@@ -154,7 +154,7 @@ describe Apia::Endpoint do
 
         context 'when cors values are set by the authenticator' do
           it 'includes the CORS headers from the authenticator in the response' do
-            request = Apia::Request.new(Rack::MockRequest.env_for('/', input: ''))
+            request = Apia::Request.new(Rack::MockRequest.env_for('/', :input => ''))
 
             authenticator = Apia::Authenticator.create('ExampleAPIAuthenticator')
             authenticator.action do
@@ -176,7 +176,7 @@ describe Apia::Endpoint do
 
         context 'when cors values are set by the authenticator and it throws an error' do
           it 'includes the CORS headers from the authenticator in the response' do
-            request = Apia::Request.new(Rack::MockRequest.env_for('/', input: ''))
+            request = Apia::Request.new(Rack::MockRequest.env_for('/', :input => ''))
 
             authenticator = Apia::Authenticator.create('ExampleAPIAuthenticator') do
               potential_error 'Failed' do
@@ -207,7 +207,7 @@ describe Apia::Endpoint do
 
       context 'when the request is an OPTIONS request' do
         it 'returns a 200 OK status' do
-          request = Apia::Request.new(Rack::MockRequest.env_for('/', input: '', method: 'OPTIONS'))
+          request = Apia::Request.new(Rack::MockRequest.env_for('/', :input => '', method: 'OPTIONS'))
           endpoint = Apia::Endpoint.create('Endpoint')
           response = endpoint.execute(request)
           expect(response.headers['Access-Control-Allow-Origin']).to eq '*'
@@ -217,7 +217,7 @@ describe Apia::Endpoint do
         end
 
         it 'does not execute the endpoint' do
-          request = Apia::Request.new(Rack::MockRequest.env_for('/', input: '', method: 'OPTIONS'))
+          request = Apia::Request.new(Rack::MockRequest.env_for('/', :input => '', method: 'OPTIONS'))
           endpoint = Apia::Endpoint.create('Endpoint')
           expect(endpoint).not_to receive(:new)
           endpoint.execute(request)
@@ -226,7 +226,7 @@ describe Apia::Endpoint do
 
       context 'when the request is not an OPTIONS request' do
         it 'executes the endpoint' do
-          request = Apia::Request.new(Rack::MockRequest.env_for('/', input: '', method: 'GET'))
+          request = Apia::Request.new(Rack::MockRequest.env_for('/', :input => '', method: 'GET'))
           endpoint = Apia::Endpoint.create('Endpoint')
           expect(endpoint).to receive(:new).and_call_original
           endpoint.execute(request)

--- a/spec/specs/apia/endpoint_spec.rb
+++ b/spec/specs/apia/endpoint_spec.rb
@@ -12,7 +12,7 @@ describe Apia::Endpoint do
   context '.execute' do
     context 'authenticators' do
       it 'should call the endpoint authenticator if one has been set' do
-        request = Apia::Request.new(Rack::MockRequest.env_for('/', :input => ''))
+        request = Apia::Request.new(Rack::MockRequest.env_for('/', input: ''))
 
         api_auth = Apia::Authenticator.create('ExampleAPIAuthenticator')
         api_auth.action { response.add_header 'x-auth', 'api' }
@@ -45,7 +45,7 @@ describe Apia::Endpoint do
       end
 
       it 'should call the controller authenticator if one has been set' do
-        request = Apia::Request.new(Rack::MockRequest.env_for('/', :input => ''))
+        request = Apia::Request.new(Rack::MockRequest.env_for('/', input: ''))
 
         api_auth = Apia::Authenticator.create('ExampleAPIAuthenticator')
         api_auth.action { response.add_header 'x-auth', 'api' }
@@ -75,7 +75,7 @@ describe Apia::Endpoint do
       end
 
       it 'should call the API authenticator' do
-        request = Apia::Request.new(Rack::MockRequest.env_for('/', :input => ''))
+        request = Apia::Request.new(Rack::MockRequest.env_for('/', input: ''))
 
         api_auth = Apia::Authenticator.create('ExampleAPIAuthenticator')
         api_auth.action { response.add_header 'x-auth', 'api' }
@@ -92,7 +92,7 @@ describe Apia::Endpoint do
       end
 
       it 'checks the scopes are valid' do
-        request = Apia::Request.new(Rack::MockRequest.env_for('/', :input => ''))
+        request = Apia::Request.new(Rack::MockRequest.env_for('/', input: ''))
 
         api_auth = Apia::Authenticator.create('ExampleAPIAuthenticator') do
           scope_validator { |e| e == 'not-example' }
@@ -130,7 +130,7 @@ describe Apia::Endpoint do
       end
 
       it 'should create an argument set from standard HTTP query string parameters' do
-        request = Apia::Request.new(Rack::MockRequest.env_for('/?name=Adam', :input => ''))
+        request = Apia::Request.new(Rack::MockRequest.env_for('/?name=Adam', input: ''))
         request.endpoint = Apia::Endpoint.create('Endpoint') do
           argument :name, type: :string
         end
@@ -144,7 +144,7 @@ describe Apia::Endpoint do
       context 'it includes CORS headers in the response' do
         context 'when nothing is specified' do
           it 'includes wildcard CORS headers' do
-            request = Apia::Request.new(Rack::MockRequest.env_for('/', :input => ''))
+            request = Apia::Request.new(Rack::MockRequest.env_for('/', input: ''))
             endpoint = Apia::Endpoint.create('Endpoint')
             response = endpoint.execute(request)
             expect(response.headers['Access-Control-Allow-Origin']).to eq '*'
@@ -154,7 +154,7 @@ describe Apia::Endpoint do
 
         context 'when cors values are set by the authenticator' do
           it 'includes the CORS headers from the authenticator in the response' do
-            request = Apia::Request.new(Rack::MockRequest.env_for('/', :input => ''))
+            request = Apia::Request.new(Rack::MockRequest.env_for('/', input: ''))
 
             authenticator = Apia::Authenticator.create('ExampleAPIAuthenticator')
             authenticator.action do
@@ -176,7 +176,7 @@ describe Apia::Endpoint do
 
         context 'when cors values are set by the authenticator and it throws an error' do
           it 'includes the CORS headers from the authenticator in the response' do
-            request = Apia::Request.new(Rack::MockRequest.env_for('/', :input => ''))
+            request = Apia::Request.new(Rack::MockRequest.env_for('/', input: ''))
 
             authenticator = Apia::Authenticator.create('ExampleAPIAuthenticator') do
               potential_error 'Failed' do
@@ -207,7 +207,7 @@ describe Apia::Endpoint do
 
       context 'when the request is an OPTIONS request' do
         it 'returns a 200 OK status' do
-          request = Apia::Request.new(Rack::MockRequest.env_for('/', :input => '', method: 'OPTIONS'))
+          request = Apia::Request.new(Rack::MockRequest.env_for('/', input: '', method: 'OPTIONS'))
           endpoint = Apia::Endpoint.create('Endpoint')
           response = endpoint.execute(request)
           expect(response.headers['Access-Control-Allow-Origin']).to eq '*'
@@ -217,7 +217,7 @@ describe Apia::Endpoint do
         end
 
         it 'does not execute the endpoint' do
-          request = Apia::Request.new(Rack::MockRequest.env_for('/', :input => '', method: 'OPTIONS'))
+          request = Apia::Request.new(Rack::MockRequest.env_for('/', input: '', method: 'OPTIONS'))
           endpoint = Apia::Endpoint.create('Endpoint')
           expect(endpoint).not_to receive(:new)
           endpoint.execute(request)
@@ -226,7 +226,7 @@ describe Apia::Endpoint do
 
       context 'when the request is not an OPTIONS request' do
         it 'executes the endpoint' do
-          request = Apia::Request.new(Rack::MockRequest.env_for('/', :input => '', method: 'GET'))
+          request = Apia::Request.new(Rack::MockRequest.env_for('/', input: '', method: 'GET'))
           endpoint = Apia::Endpoint.create('Endpoint')
           expect(endpoint).to receive(:new).and_call_original
           endpoint.execute(request)

--- a/spec/specs/apia/endpoint_spec.rb
+++ b/spec/specs/apia/endpoint_spec.rb
@@ -198,6 +198,8 @@ describe Apia::Endpoint do
             end
 
             response = endpoint.execute(request)
+
+            expect(response.status).to eq 500
             expect(response.headers['Access-Control-Allow-Origin']).to eq 'example.com'
             expect(response.headers['Access-Control-Allow-Methods']).to eq 'GET, POST'
             expect(response.headers['Access-Control-Allow-Headers']).to eq 'X-Custom'

--- a/spec/specs/apia/request_spec.rb
+++ b/spec/specs/apia/request_spec.rb
@@ -41,7 +41,7 @@ describe Apia::Request do
     end
 
     it 'should return a hash if no body is provided but there is an _arguments parameter containing a string' do
-      request = Apia::Request.new(Rack::MockRequest.env_for('/', params: { _arguments: '{"name":"Jamie"}' }))
+      request = Apia::Request.new(Rack::MockRequest.env_for('/', params: { _arguments: '{"name":"Jamie"}' }, input: ''))
       expect(request.json_body).to be_a Hash
       expect(request.json_body['name']).to eq 'Jamie'
     end


### PR DESCRIPTION
Also fix CI issues:

 - `rack.input` is not longer set by default in mock request, so we need to always set it
 - Limiting issues: 
    - add_runtime_dependency is deprecated in favour of add_dependency
    - params are not required for `super` when the method signature is unchanged