### PR TITLE
feat: Allow JSON requests with a vendor specific JSON content type

### DIFF
--- a/lib/apia/request.rb
+++ b/lib/apia/request.rb
@@ -58,7 +58,9 @@ module Apia
     end
 
     def get_json_body_from_body
-      return unless content_type =~ /\Aapplication\/json/
+      # Allow for either standard json content type (ie: application/json)
+      # or a vendor specific type with a json suffix (eg: application/vnd.docker.distribution.events.v2+json)
+      return unless content_type =~ /\Aapplication\/(|.*\+)json/
       return unless body?
 
       parse_json_from_string(body.read)

--- a/spec/specs/apia/request_spec.rb
+++ b/spec/specs/apia/request_spec.rb
@@ -12,13 +12,19 @@ describe Apia::Request do
   end
 
   context '#json_body' do
-    it 'should return nil if the content type is not application/json' do
-      request = Apia::Request.new(Rack::MockRequest.env_for('/'))
+    it 'should return nil if the content type is not json' do
+      request = Apia::Request.new(Rack::MockRequest.env_for('/', 'CONTENT_TYPE' => 'application/vnd.docker.distribution.events.v2-json', :input => '{"name":"Lauren"}'))
       expect(request.json_body).to be nil
     end
 
     it 'should return a hash when valid JSON is provided' do
       request = Apia::Request.new(Rack::MockRequest.env_for('/', 'CONTENT_TYPE' => 'application/json', :input => '{"name":"Lauren"}'))
+      expect(request.json_body).to be_a Hash
+      expect(request.json_body['name']).to eq 'Lauren'
+    end
+
+    it 'should return a hash when valid JSON is provided with a vendor specific json content type' do
+      request = Apia::Request.new(Rack::MockRequest.env_for('/', 'CONTENT_TYPE' => 'application/vnd.docker.distribution.events.v2+json', :input => '{"name":"Lauren"}'))
       expect(request.json_body).to be_a Hash
       expect(request.json_body['name']).to eq 'Lauren'
     end


### PR DESCRIPTION
We found Apia was rejecting webhook requests from distribution as the content type was not `application/json` but `application/vnd.docker.distribution.events.v2+json`

This change allows for either standard json content type (ie: `application/json`) or a vendor specific type with a `+json` suffix (eg: `application/vnd.docker.distribution.events.v2+json`)